### PR TITLE
Performance optimization

### DIFF
--- a/LUA/ak/io/AkCommandExecutor.lua
+++ b/LUA/ak/io/AkCommandExecutor.lua
@@ -22,49 +22,67 @@ local allowedFunctions = {
     'print',
     'AkKreuzungSchalteManuell',
     'AkKreuzungSchalteAutomatisch',
-    'EEPSetCamera',
 }
 
 function AkCommandExecutor.callSave(functionAndArgs)
     local fName = table.remove(functionAndArgs, 1)
     local args = functionAndArgs
+	local accepted = false
+	
+	if fName == "" then return end				-- ignore empty commands
 
     --for i, arg in ipairs(args) do
     --    print(i .. "-" .. arg)
     --end
-    for _, allowedName in ipairs(allowedFunctions) do
-        if fName == allowedName then
-            --print("Calling >" .. fName .. "<(...)")
-            pcall(_G[fName], table.unpack(args))
+	
+	if string.find(fName, "^EEP.*Set") 			-- Accept all EEP-Set-functions 
+	then
+		accepted = true
+	else
+		for _, allowedName in ipairs(allowedFunctions) do
+			if fName == allowedName then
+				accepted = true
+				break
+			end
+		end
+	end
 
-            --local functionWithTable = fName:split(".")
-            --local t = functionWithTable[2] and functionWithTable[1] or nil
-            --local f = functionWithTable[2] and functionWithTable[2] or functionWithTable[1]
-            --print(table.concat(functionWithTable, "."))
-            --print("Table:    " .. (t and tostring(t) or '-'))
-            --print("Function: " .. tostring(f))
-            --local success, error
-            --if t then
-            --    if not _G[t] then
-            --        print('Table _G[' .. t .. '] does not exist')
-            --    end
-            --    if not _G[t][f] then
-            --        print('Table _G[' .. t .. '][' .. f .. '] does not exist')
-            --    end
-            --    print("Calling >" .. t .. "<>" .. f .. "(...)")
-            --    success, error = pcall(_G[t][f], table.unpack(args))
-            --else
-            --    print("Calling >" .. f .. "<(...)")
-            --    success, error = pcall(_G[f], table.unpack(args))
-            --end
-            --if not success then
-            --    print('Cannot execute "' .. fName .. '(' ..  table.concat(args, ', ') .. ')"')
-            --    print(error)
-            --end
-            return
-        end
-    end
-    print('Nicht erlaubt: ' .. fName)
+	if accepted then
+		--print("Calling >" .. fName .. "<(...)")
+		if pcall(_G[fName], table.unpack(args)) 
+		then
+			print("Aufruf von " .. fName)
+		else
+			print("Aufruf von " .. fName .. " fehlgeschlagen")
+		end
+
+		--local functionWithTable = fName:split(".")
+		--local t = functionWithTable[2] and functionWithTable[1] or nil
+		--local f = functionWithTable[2] and functionWithTable[2] or functionWithTable[1]
+		--print(table.concat(functionWithTable, "."))
+		--print("Table:    " .. (t and tostring(t) or '-'))
+		--print("Function: " .. tostring(f))
+		--local success, error
+		--if t then
+		--    if not _G[t] then
+		--        print('Table _G[' .. t .. '] does not exist')
+		--    end
+		--    if not _G[t][f] then
+		--        print('Table _G[' .. t .. '][' .. f .. '] does not exist')
+		--    end
+		--    print("Calling >" .. t .. "<>" .. f .. "(...)")
+		--    success, error = pcall(_G[t][f], table.unpack(args))
+		--else
+		--    print("Calling >" .. f .. "<(...)")
+		--    success, error = pcall(_G[f], table.unpack(args))
+		--end
+		--if not success then
+		--    print('Cannot execute "' .. fName .. '(' ..  table.concat(args, ', ') .. ')"')
+		--    print(error)
+		--end
+	else
+		print("Aufruf von " .. fName .. " nicht erlaubt")
+	end	
 end
 
 function AkCommandExecutor.execute(commands)

--- a/LUA/ak/io/AkStatistik.lua
+++ b/LUA/ak/io/AkStatistik.lua
@@ -2,109 +2,132 @@ local AkWebServerIo = require("ak.io.AkWebServerIo")
 print("Lade ak.io.AkStatistik ...")
 
 local AkDataSlots = require("ak.data.AkDataSlots")
+
 local os = require("os")
 local json = require("ak.io.dkjson")
 
 local AkStatistik = {}
-AkStatistik.programVersion = "0.8.3"
+AkStatistik.programVersion = "0.8.3 mod"
 local MAX_SIGNALS = 1000
+local MAX_SWITCHES = 1000
 local MAX_TRACKS = 50000
 local MAX_STRUCTURES = 50000
 local data = {}
 
 local function fillTime()
-    data["time"] = { times = {
-        timeComplete = EEPTime;
-        timeH = EEPTimeH;
-        timeM = EEPTimeM;
-        timeS = EEPTimeS;
-    } }
+-- do it frequently
+	data["times"] = { {
+		name = "times",					-- EEP-Web requires that data entries have an id or name tag 
+		timeComplete = EEPTime,			-- seconds since midnight
+		timeH = EEPTimeH,
+		timeM = EEPTimeM,
+		timeS = EEPTimeS,
+	}}
 end
 
 local function fillEEPVersion()
-    data["eep-version"] = { versionInfo = {
-        eepVersion = EEPVer,
-        luaVersion = AkStatistik.programVersion,
-        singleVersion = {
-            AkStatistik = AkStatistik.programVersion,
-        } },
-    }
+-- do it once
+    data["eep-version"] = { versionInfo = {				-- EEP-Web expects an named entry here 
+		name = "versionInfo",							-- EEP-Web requires that data entries have an id or name tag 
+		eepVersion = string.format("%.1f", EEPVer),		-- show string instead of float
+		luaVersion = _VERSION,
+		singleVersion = { AkStatistik = AkStatistik.programVersion, },	-- Web-EEP does not show this object value
+	}}
 end
 
 local function fillSaveSlots()
     data["save-slots"] = AkDataSlots.fillApiV1()
-    data["free-slots"] = AkDataSlots.fillFreeSlotsApiV1()
+--	data["free-slots"] = AkDataSlots.fillFreeSlotsApiV1()	-- omit free slots to save space
+end
+
+local function registerSignals()
+-- do it once
+    data["signals"] = {}
+    for i = 1, MAX_SIGNALS do
+        local val = EEPGetSignal(i)
+        if val > 0 then			-- yes, this is a signal
+            local signal = {}
+            signal.id = i
+            table.insert(data["signals"], signal)
+        end
+    end
 end
 
 local function fillSignals()
-    data["signals"] = {}
+-- do it frequently
     data["waiting-on-signals"] = {}
-    for i = 1, MAX_SIGNALS do
-        local val = EEPGetSignal(i)
-        if val > 0 then
-            local waitingVehiclesCount = 0;
-            if EEPVer >= 13.2 then
-                waitingVehiclesCount = EEPGetSignalTrainsCount(i)
-            end
-            local o = {}
-            o.id = i
-            o.position = val
-            o.waitingVehiclesCount = waitingVehiclesCount
-            table.insert(data["signals"], o)
+    for i = 1, #data["signals"] do
+		local signal = data["signals"][i]
+		signal.position = EEPGetSignal(signal.id)
+		local waitingVehiclesCount = 0;
+		if EEPVer >= 13.2 then
+			waitingVehiclesCount = EEPGetSignalTrainsCount(signal.id)
+		end
+		signal.waitingVehiclesCount = waitingVehiclesCount
 
-            if (waitingVehiclesCount > 0) then
-                for position = 1, waitingVehiclesCount do
-                    local vehicleName = EEPGetSignalTrainName(i, position)
-                    local waiting = {
-                        id = o.id .. "-" .. position,
-                        signalId = o.id,
-                        waitingPosition = position,
-                        vehicleName = vehicleName,
-                        waitingCount = waitingVehiclesCount
-                    }
-                    table.insert(data["waiting-on-signals"], waiting)
-                end
-            end
+		if (waitingVehiclesCount > 0) then
+			for position = 1, waitingVehiclesCount do
+				local vehicleName = ""; 
+				if EEPVer >= 13.2 then
+					vehicleName = EEPGetSignalTrainName(signal.id, position)
+				end	
+				local waiting = {
+					id = signal.id .. "-" .. position,
+					signalId = signal.id,
+					waitingPosition = position,
+					vehicleName = vehicleName,
+					waitingCount = waitingVehiclesCount
+				}
+				table.insert(data["waiting-on-signals"], waiting)
+			end
+		end
+    end
+end
+
+local function registerSwitches()
+-- do it once
+    data["switches"] = {}
+    for id = 1, MAX_SWITCHES do
+        local val = EEPGetSwitch(id)
+        if val > 0 then			-- yes, this is a switch
+            local switch = {}
+            switch.id = id
+            table.insert(data["switches"], switch)
         end
     end
 end
 
 local function fillSwitches()
-    data["switches"] = {}
-    for i = 1, MAX_SIGNALS do
-        local val = EEPGetSignal(i)
-        if val > 0 then
-            local o = {}
-            o.id = i
-            o.position = val
-            table.insert(data["switches"], o)
-        end
+-- do it frequently
+    for i = 1, #data["switches"] do
+		local switch = data["switches"][i]
+        switch.position = EEPGetSwitch(switch.id)
     end
 end
 
 local function registerTracksBy(registerFunktion, trackType)
+-- do it once
     local trackName = trackType .. "-tracks"
     data[trackName] = {}
-    for i = 1, MAX_TRACKS do
-        local exists = registerFunktion(i)
+    for id = 1, MAX_TRACKS do
+        local exists = registerFunktion(id)
         if exists then
-            local o = {}
-            o.id = i
-            --o.position = val
-            data[trackName][tostring(o.id)] = o
+            local track = {}
+            track.id = id
+            --track.position = val
+            data[trackName][tostring(track.id)] = track
         end
     end
 end
 
 local function registerTracks()
+-- do it once
     registerTracksBy(EEPRegisterAuxiliaryTrack, "auxiliary")
     registerTracksBy(EEPRegisterControlTrack, "control")
     registerTracksBy(EEPRegisterRoadTrack, "road")
     registerTracksBy(EEPRegisterRailTrack, "rail")
     registerTracksBy(EEPRegisterTramTrack, "tram")
 end
-
-
 
 local function fillTracksBy(besetztFunktion, trackType)
     local trackName = trackType .. '-tracks'
@@ -169,7 +192,8 @@ local function fillTracksBy(besetztFunktion, trackType)
         -- data[trainList][tostring(currentTrain.id)] = currentTrain
         local trainsInfo = {
             id = trainName,
-            speed = haveSpeed and speed or 0,
+			speed = haveSpeed and speed --string.format("%.2f", speed)
+						or 0,
             onTrackId = train.onTrack,
             occupiedTacks = train.occupiedTacks,
         }
@@ -199,13 +223,13 @@ local function fillTracksBy(besetztFunktion, trackType)
             local modelType = -1
             local tag = ''
 
-            if EEPVer >= 15 then
+            if EEPVer >= 14.2 then
                 _, length = EEPRollingstockGetLength(rollingStockName)
                 _, propelled = EEPRollingstockGetMotor(rollingStockName)
                 _, trackId, trackDistance, trackDirection, trackSystem = EEPRollingstockGetTrack(rollingStockName)
                 _, modelType = EEPRollingstockGetModelType(rollingStockName)
                 _, tag = EEPRollingstockGetTagText(rollingStockName)
-            end
+			end
 
             local currentRollingStock = {
                 name = rollingStockName,
@@ -213,7 +237,7 @@ local function fillTracksBy(besetztFunktion, trackType)
                 positionInTrain = i,
                 couplingFront = couplingFront,
                 couplingRear = couplingRear,
-                length = length,
+				length = length, --string.format("%.2f", length),
                 propelled = propelled,
                 trackSystem = trackSystem,
                 modelType = modelType,
@@ -224,7 +248,7 @@ local function fillTracksBy(besetztFunktion, trackType)
             local rollingStockInfo = {
                 name = rollingStockName,
                 trackId = trackId,
-                trackDistance = trackDistance,
+				trackDistance = trackDistance, --string.format("%.2f", trackDistance),
                 trackDirection = trackDirection,
             }
             table.insert(data[rollingStockInfos], rollingStockInfo)
@@ -241,38 +265,58 @@ local function fillTracks()
     fillTracksBy(EEPIsTramTrackReserved, "tram")
 end
 
-local function fillStructures()
+local function registerStructures()
     data["structures"] = {}
     for i = 0, MAX_STRUCTURES do
         local name = "#" .. tostring(i)
-        local pos_x, pos_y, pos_z = 0, 0, 0
-        local t, modelType = false, 0
-        local tag = ''
-        if (EEPVer >= 15) then
-            local _
-            _, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
-            _, modelType = EEPStructureGetModelType(name)
-            t, tag = EEPStructureGetTagText(name)
-        end
 
-        if (t) then
-            local _, light = EEPStructureGetLight(name)
-            local _, smoke = EEPStructureGetSmoke(name)
-            local _, fire = EEPStructureGetFire(name)
+		local hasLight, light = EEPStructureGetLight(name)
+		local hasSmoke, smoke = EEPStructureGetSmoke(name)
+		local hasFire, fire = EEPStructureGetFire(name)
 
-            local o = {
-                name = name,
-                light = light,
-                smoke = smoke,
-                fire = fire,
-                pos_x = pos_x,
-                pos_y = pos_y,
-                pos_z = pos_z,
-                modelType = modelType,
-                tag = tag,
-            }
-            table.insert(data["structures"], o)
-        end
+		if hasLight or hasSmoke or hasFire then
+			local structure = {}
+            structure.name = name
+			
+			local pos_x, pos_y, pos_z = 0, 0, 0
+			local modelType = 0
+			local tag = ''
+			local _
+			if (EEPVer >= 14.2) then
+				_, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
+				_, modelType = EEPStructureGetModelType(name)
+					-- 16 = Tracks/Track objects
+					-- 17 = Tramtracks/Tramtrack objects
+					-- 18 = Streets/Street objects
+					-- 19 = Other/Other objects
+					-- 22 = Real estate
+					-- 23 = landscape elements/Fauna
+					-- 24 = landscape elements/Flora
+					-- 25 = landscape elements/Terra
+					-- 38 = landscape elements/Instancing			
+				_, tag = EEPStructureGetTagText(name)
+			end
+			structure.pos_x = pos_x --string.format("%.2f", pos_x)
+			structure.pos_y = pos_y --string.format("%.2f", pos_y)
+			structure.pos_z = pos_z --string.format("%.2f", pos_z)
+			structure.modelType = modelType
+			structure.tag = tag
+			table.insert(data["structures"], structure)
+		end
+    end
+end
+
+local function fillStructures()
+    for i = 1, #data["structures"] do
+		local structure = data["structures"][i]
+
+		local _, light = EEPStructureGetLight(structure.name)
+		local _, smoke = EEPStructureGetSmoke(structure.name)
+		local _, fire = EEPStructureGetFire(structure.name)
+
+		structure.light = light
+		structure.smoke = smoke
+		structure.fire = fire
     end
 end
 
@@ -309,41 +353,57 @@ local function fillApiV1(dataKeys)
 end
 
 local function initialize()
+	print("AkStatistik: init")
+
+	-- prepare data once
+	registerSignals()
+	registerSwitches()
     registerTracks()
+	registerStructures()
+
+    -- export data once
+	fillEEPVersion()
 end
 
 local i = -1
 local writeLater = {}
 function AkStatistik.statistikAusgabe(modulus)
-    AkWebServerIo.processNewCommands()
-    if i == -1 then
-        initialize();
-    end
+-- call this function in main loop 
 
-    -- Increase
-    i = i + 1
-    if not modulus or type(modulus) ~= "number" then
+ 	-- default value for optional parameter
+   if not modulus or type(modulus) ~= "number" then
         modulus = 5
     end
 
-    -- Do nothing
+	-- initialization in first call
+    if i == -1 then
+        initialize();
+    end
+    i = i + 1
+
+	-- process commands 
+    AkWebServerIo.processNewCommands()
+
+    -- export data regularly
     if i % modulus == 0 then
-        local t1 = os.time()
-        fillTime()
-        fillEEPVersion()
-        fillStructures()
+        local t0 = os.clock()	-- milliseconds precision
+		
+		fillTime()
+		fillStructures()
 
-        fillSignals()
-        fillSwitches()
-        fillTracks()
-        fillTrainYards()
+		fillSignals()
+		fillSwitches()
+		fillTracks()
+		fillTrainYards()	-- not implemented yet
 
-        fillSaveSlots()
+		fillSaveSlots()		--let's omit Slots for now
 
+		-- add delayed data
         for key, value in pairs(writeLater) do
             data[key] = value
         end
 
+		-- add statistical data
         data["api-entries"] = {}
         local topLevelEntries = {}
         for k in pairs(data) do
@@ -352,19 +412,31 @@ function AkStatistik.statistikAusgabe(modulus)
         table.sort(topLevelEntries)
         data.apiV1 = fillApiV1(topLevelEntries)
 
+        local t1 = os.clock()
+
+		-- export data
         AkWebServerIo.updateJsonFile(json.encode(data, {
             keyorder = topLevelEntries,
         }))
+		
+		-- clear delayed data
         writeLater = {}
-        local t2 = os.time()
-        local timeDiff = os.difftime(t2, t1)
+		
+        local t2 = os.clock()
+		print("AkStatistik:" 
+			.. " fill: "  .. string.format("%.2f", t1-t0) .. " sec,"
+			.. " store: " .. string.format("%.2f", t2-t1) .. " sec"
+			)
+
+        local timeDiff = t2 - t0
         if timeDiff > 1 then
-            print("WARNUNG: AkStatistik.statistikAusgabe schreiben dauerte " .. timeDiff
+            print("WARNUNG: AkStatistik.statistikAusgabe schreiben dauerte " .. string.format("%.2f", timeDiff)
                     .. " Sekunden (nur interessant, wenn EEP nicht pausiert wurde)")
         end
     end
 end
 
+-- store delayed data (where is this used?)
 function AkStatistik.writeLater(key, value)
     writeLater[key] = value
 end

--- a/LUA/ak/io/AkWebServerIo.lua
+++ b/LUA/ak/io/AkWebServerIo.lua
@@ -5,7 +5,7 @@ local AkWebServerIo = {}
 
 local function dirExists(dir)
     local file = io.open(dir .. "/" .. "ak-eep-version.txt", "w")
-    file:write(EEPVer)
+    file:write( string.format("%.1f", EEPVer) ) 
     file:flush()
     file:close()
     return true
@@ -48,13 +48,13 @@ local inFileCommands
 function AkWebServerIo.setOutputDirectory(dirName)
     assert(dirName, "Verzeichnis angeben!")
 
-    ioDirectoryName = dirName
-    outFileNameLog = ioDirectoryName .. '/ak-eep-out.socket'
-    outFileNameJson = ioDirectoryName .. '/ak-eep-out.json'
-    watchFileNameServer = ioDirectoryName .. '/ak-server.iswatching'
-    watchFileNameLua = ioDirectoryName .. '/ak-eep-out-json.isfinished'
+	ioDirectoryName 			= dirName
+	outFileNameLog 				= ioDirectoryName .. '/ak-eep-out.socket'
+	outFileNameJson 			= ioDirectoryName .. '/ak-eep-out.json'
+	watchFileNameServer 		= ioDirectoryName .. '/ak-server.iswatching'
+	watchFileNameLua 			= ioDirectoryName .. '/ak-eep-out-json.isfinished'
 
-    local inFileNameCommands = ioDirectoryName .. '/ak-eep-in.commands'
+    local inFileNameCommands 	= ioDirectoryName .. '/ak-eep-in.commands'
     writeFile(inFileNameCommands, "")
     inFileCommands = io.open(inFileNameCommands, "r")
 end
@@ -95,7 +95,10 @@ function clearlog()
     io.open(outFileNameLog, "w+"):close()
 end
 
-AkWebServerIo.setOutputDirectory(existingDirOf({ "../LUA/ak/io/exchange", "./LUA/ak/io/exchange" }) or ".")
+AkWebServerIo.setOutputDirectory(existingDirOf({ 
+	"../LUA/ak/io/exchange", 
+	"./LUA/ak/io/exchange" 
+}) or ".")
 
 local writing = false
 ---
@@ -103,22 +106,22 @@ local writing = false
 --- @param type - Inhaltstyp
 --- @param jsonData - Dateiinhalt
 function AkWebServerIo.updateJsonFile(jsonData)
-    if fileExists(watchFileNameServer)
-            and fileExists(watchFileNameLua) then
+	if fileExists(watchFileNameServer)								-- file: ak-server.iswatching
+		and fileExists(watchFileNameLua) then						-- file: ak-eep-out-json.isfinished
         print("SKIPPING - server not ready")
         return
     end
 
     if not writing then
         writing = true
-        if not pcall(writeFile, outFileNameJson, jsonData) then
+        if not pcall(writeFile, outFileNameJson, jsonData) then		-- file: ak-eep-out.json
             print("CANNOT WRITE TO " .. outFileNameJson)
         end
         writing = false
     end
 
-    if fileExists(watchFileNameServer) then
-        writeFile(watchFileNameLua, "")
+    if fileExists(watchFileNameServer) then							-- file: ak-server.iswatching
+        writeFile(watchFileNameLua, "")								-- file: ak-eep-out-json.isfinished
     end
 end
 
@@ -126,7 +129,7 @@ end
 --- Liest Inhalte von der Eingabe "type"
 --- @param type
 function AkWebServerIo.processNewCommands()
-    local commands = inFileCommands:read()
+    local commands = inFileCommands:read()							-- file: ak-eep-in.commands
     if (commands) then
         AkCommandExecutor.execute(commands)
     end


### PR DESCRIPTION
- Performance optimization: Split one-time tasks and repeated tasks
- add name to eep-version and times to allow EEP-Web to show these entries
- omit free slots to save space in the file
- use os.clock istead of os.time to make use of milli seconds precision
- some EEP functions are already available in 14.2 
- allow calling of all EEP*Set* functions
- show EEP version as string like "15.1" instead of floating point number
- correct bug to call EEPGetSwitch instead of EEPGetSignal for switches
