### PR TITLE
Improved DataLuaModule

### DIFF
--- a/lua/LUA/ak/core/CoreLuaModule.lua
+++ b/lua/LUA/ak/core/CoreLuaModule.lua
@@ -38,6 +38,23 @@ function CoreLuaModule.run()
     -- Das CoreModul hat keine wiederkehrenden Funktionen
 end
 
+--- Über diese Funktion kann das EEP Skript die Optionen des Moduls setzen
+-- @author Frank Buchholz
+-- @options List of options { waitForServer = true/false, activeEntries = array of entry names, }
+local ServerController = require("ak.io.ServerController")
+function CoreLuaModule.setOptions(options)
+    if options.waitForServer == nil then -- it seems to be difficult to distinguish between nil, true, false
+    else -- however this way it works
+        ServerController.checkServerStatus = options.waitForServer
+    end
 
+    if options.activeEntries then
+        local entriesList = {}
+        for key, value in pairs(options.activeEntries) do
+            entriesList[value] = true
+        end
+        ServerController.activeEntries = entriesList
+    end
+end
 
 return CoreLuaModule

--- a/lua/LUA/ak/core/CoreLuaModule.lua
+++ b/lua/LUA/ak/core/CoreLuaModule.lua
@@ -43,14 +43,13 @@ end
 -- @options List of options { waitForServer = true/false, activeEntries = array of entry names, }
 local ServerController = require("ak.io.ServerController")
 function CoreLuaModule.setOptions(options)
-    if options.waitForServer == nil then -- it seems to be difficult to distinguish between nil, true, false
-    else -- however this way it works
+    if options.waitForServer ~= nil then
         ServerController.checkServerStatus = options.waitForServer
     end
 
     if options.activeEntries then
         local entriesList = {}
-        for key, value in pairs(options.activeEntries) do
+        for _, value in pairs(options.activeEntries) do
             entriesList[value] = true
         end
         ServerController.activeEntries = entriesList

--- a/lua/LUA/ak/core/ModuleRegistry.lua
+++ b/lua/LUA/ak/core/ModuleRegistry.lua
@@ -29,6 +29,9 @@ function ModuleRegistry.registerModules(...)
         -- Remember the module by it's name
         registeredLuaModules[module.name] = module
     end
+
+    -- pass the modules to the caller in the EEP script
+    return registeredLuaModules
 end
 
 ---
@@ -102,35 +105,6 @@ end
 
 function ModuleRegistry.deactivateServer()
     enableServer = false
-end
-
----
--- Set option of the ServerController
--- @param flag true(default)/false to decide if Lua should check if the EEP Server is running and ready
-function ModuleRegistry.setWaitForServer(flag)
-    ServerController.checkServerStatus = flag
-end
-
----
--- DataLuaModule: register jsonCollectors (default = all)
--- @param Array of jsonCollector names
-function ModuleRegistry.registerCollectors(collectorsArray)
-    local collectorsList = {}
-    for key, value in pairs(collectorsArray) do
-        collectorsList[value] = true
-    end
-    ServerController.activeCollectors = collectorsList
-end
-
----
--- DataLuaModule: set active entries (default = all)
--- @param Array of entry names
-function ModuleRegistry.setActiveEntries(entriesArray)
-    local entriesList = {}
-    for key, value in pairs(entriesArray) do
-        entriesList[value] = true
-    end
-    ServerController.activeEntries = entriesList
 end
 
 -- Register the core module to hold basic data

--- a/lua/LUA/ak/core/ModuleRegistry.lua
+++ b/lua/LUA/ak/core/ModuleRegistry.lua
@@ -111,6 +111,28 @@ function ModuleRegistry.setWaitForServer(flag)
     ServerController.checkServerStatus = flag
 end
 
+---
+-- DataLuaModule: register jsonCollectors (default = all)
+-- @param Array of jsonCollector names
+function ModuleRegistry.registerCollectors(collectorsArray)
+    local collectorsList = {}
+    for key, value in pairs(collectorsArray) do
+        collectorsList[value] = true
+    end
+    ServerController.activeCollectors = collectorsList
+end
+
+---
+-- DataLuaModule: set active entries (default = all)
+-- @param Array of entry names
+function ModuleRegistry.setActiveEntries(entriesArray)
+    local entriesList = {}
+    for key, value in pairs(entriesArray) do
+        entriesList[value] = true
+    end
+    ServerController.activeEntries = entriesList
+end
+
 -- Register the core module to hold basic data
 do
     local CoreLuaModule = require("ak.core.CoreLuaModule")

--- a/lua/LUA/ak/core/README.md
+++ b/lua/LUA/ak/core/README.md
@@ -1,7 +1,7 @@
 ---
 layout: page_with_toc
 title: Der Kern der App
-subtitle: Dieser Teil enthält das Standardmodul 
+subtitle: Dieser Teil enthält das Standardmodul
 permalink: lua/ak/eep/
 feature-img: "/docs/assets/headers/SourceCode.png"
 img: "/docs/assets/headers/SourceCode.png"
@@ -21,7 +21,7 @@ Hier ein minimales Beispiel (bei dem die Kreuzungssteuerung genutzt wird):
 ```lua
 local ModuleRegistry = require("ak.core.ModuleRegistry")
 ModuleRegistry.registerModules(
-    -- require("ak.core.CoreLuaModule"), -- loaded automatically 
+    -- require("ak.core.CoreLuaModule"), -- loaded automatically
     require("ak.strasse.KreuzungLuaModul")
 )
 
@@ -33,7 +33,7 @@ end
 
 ## Verwendung von DataLuaModule / erweitertes Beispiel
 
-Das Modul `DataLuaModule` kann, wie im vorigen Abschnitt beschrieben, aufgerufen werden. 
+Das Modul `DataLuaModule` kann, wie im vorigen Abschnitt beschrieben, aufgerufen werden.
 
 Es bietet zusätzliche Optionen an, mit der die Auswahl den Daten-Kollektoren und die Auswahl der zu exportierenden Daten genau eingestellt werden kann.
 
@@ -41,85 +41,92 @@ Dazu dienen die zusätzlichen Funktionen `registerCollectors` und `setActiveEntr
 
 Mit der Funktion `setWaitForServer` kann festgelegt werden, ob die Dateien immer aktualiert werden sollen oder ob dies nur geschehen soll wenn der EEP-Webserver aktiv und empfangsbereit ist (default).
 
-Die Funktion `runTasks()` besitzt einen zusätzlichen Parameter mit der angegeben werden kann nach wievielen Zyklen die Dateien aktualisiert werden sollen. 
+Die Funktion `runTasks()` besitzt einen zusätzlichen Parameter mit der angegeben werden kann nach wievielen Zyklen die Dateien aktualisiert werden sollen.
 
-Die Standardfunktion `clearlog()` wird von dem Modul überladen. Damit wird dann nicht nur das Protokoll in EEP gelöscht sondern auch der Inhalt der exportierten Log-Datei.  
+Die Standardfunktion `clearlog()` wird von dem Modul überladen. Damit wird dann nicht nur das Protokoll in EEP gelöscht sondern auch der Inhalt der exportierten Log-Datei.
 
 ```
 clearlog() -- This call before loading EEP-Web clears the log within EEP but does not clear the log file of EEP Web
 
 -- Load EEP Web Modules
 local ModuleRegistry = require("ak.core.ModuleRegistry")
-ModuleRegistry.registerModules(
---  require("ak.core.CoreLuaModule"), -- loaded automatically 
+local modules = ModuleRegistry.registerModules(
+    require("ak.core.CoreLuaModule"),
     require("ak.data.DataLuaModule")
 )
--- DataLuaModule: register JsonCollectors (default = all)
-ModuleRegistry.registerCollectors({
---  "ak.data.DataSlotsJsonCollector",
---  "ak.data.SignalJsonCollector",
---  "ak.data.SwitchJsonCollector",
---  "ak.data.StructureJsonCollector",
---  "ak.data.TimeJsonCollector",
---  "ak.data.TrainsAndTracksJsonCollector",
-})
--- DataLuaModule: set active entries (default = all)
-ModuleRegistry.setActiveEntries({
-    -- Collector: common
---  "api-entries",
 
-    -- Collector: "ak.data.TimeJsonCollector",
---  "times",
-
-    -- Collector: "ak.core.VersionJsonCollector",
---  "eep-version",
-
-    -- Collector: "ak.data.TrainsAndTracksJsonCollector",
---  "rail-rolling-stock-infos-dynamic",
---  "rail-rolling-stocks",
---  "rail-tracks",
---  "rail-train-infos-dynamic",
---  "rail-trains",
---  "tram-rolling-stock-infos-dynamic",
---  "tram-rolling-stocks",
---  "tram-tracks",
---  "tram-train-infos-dynamic",
---  "tram-trains",
---  "road-rolling-stock-infos-dynamic",
---  "road-rolling-stocks",
---  "road-tracks",
---  "road-train-infos-dynamic",
---  "road-trains",
---  "auxiliary-rolling-stock-infos-dynamic",
---  "auxiliary-rolling-stocks",
---  "auxiliary-tracks",
---  "auxiliary-train-infos-dynamic",
---  "auxiliary-trains",
---  "control-rolling-stock-infos-dynamic",
---  "control-rolling-stocks",
---  "control-tracks",
---  "control-train-infos-dynamic",
---  "control-trains",
---  "runtime",
-
-    -- Collector: "ak.data.SwitchJsonCollector",
---  "switches",
-
-    -- Collector: "ak.data.SignalJsonCollector",
---  "signals",
---  "waiting-on-signals",
-
-    -- Collector: "ak.data.StructureJsonCollector",
---  "structures",
-
-    -- Collector: "ak.data.DataSlotsJsonCollector",
---  "save-slots",
---  "free-slots",
-
+-- Optional: Set options of CoreLuaModule
+modules["ak.core.CoreLuaModule"].setOptions({
+    waitForServer = false, -- false: Allow to update the json file without checking if the Web Server is ready
 })
 
--- Allow to update the json file without checking if the Web Server is ready
-ModuleRegistry.setWaitForServer(true) 
+-- Optional: Set options of DataLuaModule
+modules["ak.data.DataLuaModule"].setOptions({
+    activeCollectors = { --register JsonCollectors (default = all)
+        --  "ak.data.DataSlotsJsonCollector",
+        --  "ak.data.SignalJsonCollector",
+        --  "ak.data.SwitchJsonCollector",
+        --  "ak.data.StructureJsonCollector",
+        --  "ak.data.TimeJsonCollector",
+          "ak.data.TrainsAndTracksJsonCollector",
+    },
+})
+
+-- Optional: Set more options of CoreLuaModule
+modules["ak.core.CoreLuaModule"].setOptions({
+    activeEntries = { -- Choose entries which get exported to file (default = empty list = all)
+        -- Collector: common
+        --  "api-entries",
+
+        -- Collector: "ak.data.TimeJsonCollector",
+        --  "times",
+
+        -- Collector: "ak.core.VersionJsonCollector",
+        --  "eep-version",
+
+        -- Collector: "ak.data.TrainsAndTracksJsonCollector",
+        --  "rail-tracks",
+          "rail-trains",
+          "rail-train-infos-dynamic",
+          "rail-rolling-stocks",
+          "rail-rolling-stock-infos-dynamic",
+        --  "tram-tracks",
+        --  "tram-trains",
+        --  "tram-train-infos-dynamic",
+        --  "tram-rolling-stocks",
+        --  "tram-rolling-stock-infos-dynamic",
+        --  "road-tracks",
+        --  "road-trains",
+        --  "road-train-infos-dynamic",
+        --  "road-rolling-stocks",
+        --  "road-rolling-stock-infos-dynamic",
+        --  "auxiliary-tracks",
+        --  "control-tracks",
+        --  "auxiliary-trains",
+        --  "auxiliary-train-infos-dynamic",
+        --  "auxiliary-rolling-stocks",
+        --  "auxiliary-rolling-stock-infos-dynamic",
+        --  "control-trains",
+        --  "control-train-infos-dynamic",
+        --  "control-rolling-stocks",
+        --  "control-rolling-stock-infos-dynamic",
+        --  "runtime",
+
+        -- Collector: "ak.data.SwitchJsonCollector",
+        --  "switches",
+
+        -- Collector: "ak.data.SignalJsonCollector",
+        --  "signals",
+        --  "waiting-on-signals",
+
+        -- Collector: "ak.data.StructureJsonCollector",
+        --  "structures",
+
+        -- Collector: "ak.data.DataSlotsJsonCollector",
+        --  "save-slots",
+        --  "free-slots",
+    },
+})
 
 --clearlog() -- This call after loading EEP Web clears the log file, too
 

--- a/lua/LUA/ak/core/README.md
+++ b/lua/LUA/ak/core/README.md
@@ -1,7 +1,7 @@
 ---
 layout: page_with_toc
 title: Der Kern der App
-subtitle: Dieser Teil enthält das Standardmodul und die 
+subtitle: Dieser Teil enthält das Standardmodul 
 permalink: lua/ak/eep/
 feature-img: "/docs/assets/headers/SourceCode.png"
 img: "/docs/assets/headers/SourceCode.png"
@@ -9,22 +9,122 @@ img: "/docs/assets/headers/SourceCode.png"
 
 # Paket ak.core
 
-* Dieses Paket enthält das Skript für das Einplanen der Aufgaben für die App.
+* Dieses Paket enthält das Skript für das Einbinden und Starten der anderen Module.
 
 Das Skript `ModuleRegistry` wird genutzt um die Module zu registrieren.
 Die Einbindung von `ModuleRegistry.runTasks()` in `EEPMain()` sorgt dafür, dass die Tasks der Module ausgeführt werden.
 
 ## Verwendung
 
+Hier ein minimales Beispiel (bei dem die Kreuzungssteuerung genutzt wird):
+
 ```lua
 local ModuleRegistry = require("ak.core.ModuleRegistry")
 ModuleRegistry.registerModules(
-    require("ak.core.CoreLuaModule"),
+    -- require("ak.core.CoreLuaModule"), -- loaded automatically 
     require("ak.strasse.KreuzungLuaModul")
 )
 
 function EEPMain()
     ModuleRegistry.runTasks()
+    return 1
+end
+```
+
+## Verwendung von DataLuaModule / erweitertes Beispiel
+
+Das Modul `DataLuaModule` kann, wie im vorigen Abschnitt beschrieben, aufgerufen werden. 
+
+Es bietet zusätzliche Optionen an, mit der die Auswahl den Daten-Kollektoren und die Auswahl der zu exportierenden Daten genau eingestellt werden kann.
+
+Dazu dienen die zusätzlichen Funktionen `registerCollectors` und `setActiveEntries`, denen Listen der jeweils aktiven Objekten übergeben werden kann. Ohne diese Ausrufe, oder wenn eine leere Liste übergeben wird, werden alle Daten gesammelt und exportiert. Im Beispiel unten werden alle Optionen angegeben (kommentiert, so dass mit diesem Beispiel leere Listen genutzt werden.)
+
+Mit der Funktion `setWaitForServer` kann festgelegt werden, ob die Dateien immer aktualiert werden sollen oder ob dies nur geschehen soll wenn der EEP-Webserver aktiv und empfangsbereit ist (default).
+
+Die Funktion `runTasks()` besitzt einen zusätzlichen Parameter mit der angegeben werden kann nach wievielen Zyklen die Dateien aktualisiert werden sollen. 
+
+Die Standardfunktion `clearlog()` wird von dem Modul überladen. Damit wird dann nicht nur das Protokoll in EEP gelöscht sondern auch der Inhalt der exportierten Log-Datei.  
+
+```
+clearlog() -- This call before loading EEP-Web clears the log within EEP but does not clear the log file of EEP Web
+
+-- Load EEP Web Modules
+local ModuleRegistry = require("ak.core.ModuleRegistry")
+ModuleRegistry.registerModules(
+--  require("ak.core.CoreLuaModule"), -- loaded automatically 
+    require("ak.data.DataLuaModule")
+)
+-- DataLuaModule: register JsonCollectors (default = all)
+ModuleRegistry.registerCollectors({
+--  "ak.data.DataSlotsJsonCollector",
+--  "ak.data.SignalJsonCollector",
+--  "ak.data.SwitchJsonCollector",
+--  "ak.data.StructureJsonCollector",
+--  "ak.data.TimeJsonCollector",
+--  "ak.data.TrainsAndTracksJsonCollector",
+})
+-- DataLuaModule: set active entries (default = all)
+ModuleRegistry.setActiveEntries({
+    -- Collector: common
+--  "api-entries",
+
+    -- Collector: "ak.data.TimeJsonCollector",
+--  "times",
+
+    -- Collector: "ak.core.VersionJsonCollector",
+--  "eep-version",
+
+    -- Collector: "ak.data.TrainsAndTracksJsonCollector",
+--  "rail-rolling-stock-infos-dynamic",
+--  "rail-rolling-stocks",
+--  "rail-tracks",
+--  "rail-train-infos-dynamic",
+--  "rail-trains",
+--  "tram-rolling-stock-infos-dynamic",
+--  "tram-rolling-stocks",
+--  "tram-tracks",
+--  "tram-train-infos-dynamic",
+--  "tram-trains",
+--  "road-rolling-stock-infos-dynamic",
+--  "road-rolling-stocks",
+--  "road-tracks",
+--  "road-train-infos-dynamic",
+--  "road-trains",
+--  "auxiliary-rolling-stock-infos-dynamic",
+--  "auxiliary-rolling-stocks",
+--  "auxiliary-tracks",
+--  "auxiliary-train-infos-dynamic",
+--  "auxiliary-trains",
+--  "control-rolling-stock-infos-dynamic",
+--  "control-rolling-stocks",
+--  "control-tracks",
+--  "control-train-infos-dynamic",
+--  "control-trains",
+--  "runtime",
+
+    -- Collector: "ak.data.SwitchJsonCollector",
+--  "switches",
+
+    -- Collector: "ak.data.SignalJsonCollector",
+--  "signals",
+--  "waiting-on-signals",
+
+    -- Collector: "ak.data.StructureJsonCollector",
+--  "structures",
+
+    -- Collector: "ak.data.DataSlotsJsonCollector",
+--  "save-slots",
+--  "free-slots",
+
+})
+
+-- Allow to update the json file without checking if the Web Server is ready
+ModuleRegistry.setWaitForServer(true) 
+
+--clearlog() -- This call after loading EEP Web clears the log file, too
+
+function EEPMain()
+    ModuleRegistry.runTasks(1) -- 1: every 200 ms, 5: every second, ...
     return 1
 end
 ```

--- a/lua/LUA/ak/data/DataLuaModule.lua
+++ b/lua/LUA/ak/data/DataLuaModule.lua
@@ -7,6 +7,10 @@ local initialized = false
 -- Jedes Modul hat einen eindeutigen Namen
 DataLuaModule.name = "ak.data.DataLuaModule"
 
+-- List of collectors which should be active (default = all)
+-- Example: { ["ak.core.VersionJsonCollector"] = true, ["ak.data.TrainsAndTracksJsonCollector"] = true, }
+local activeCollectors = {}
+
 --- Diese Funktion wird einmalig durch ModuleRegistry.initTasks() aufgerufen
 -- Ist ein Modul für EEPWeb vorhanden, dann solltes in dieser Funktion aufgerufen werden
 -- @author Andreas Kreuz
@@ -17,7 +21,7 @@ function DataLuaModule.init()
 
     -- Hier wird der DataWebConnector registriert, so dass die Kommunikation mit der WebApp funktioniert
     local DataWebConnector = require("ak.data.DataWebConnector")
-    DataWebConnector.registerJsonCollectors()
+    DataWebConnector.registerJsonCollectors(activeCollectors)
 
     initialized = true
 end
@@ -33,4 +37,17 @@ function DataLuaModule.run()
     -- Das CoreModul hat keine wiederkehrenden Funktionen
 end
 
+--- Über diese Funktion kann das EEP Skript die Optionen des Moduls setzen
+-- @author Frank Buchholz
+-- @options List of options { activeCollectors = array of jsonCollector names, }
+local ServerController = require("ak.io.ServerController")
+function DataLuaModule.setOptions(options)
+    if options.activeCollectors then
+        local collectorsList = {}
+        for key, value in pairs(options.activeCollectors) do
+            collectorsList[value] = true
+        end
+        activeCollectors = collectorsList
+    end
+end
 return DataLuaModule

--- a/lua/LUA/ak/data/DataLuaModule.lua
+++ b/lua/LUA/ak/data/DataLuaModule.lua
@@ -40,11 +40,10 @@ end
 --- Über diese Funktion kann das EEP Skript die Optionen des Moduls setzen
 -- @author Frank Buchholz
 -- @options List of options { activeCollectors = array of jsonCollector names, }
-local ServerController = require("ak.io.ServerController")
 function DataLuaModule.setOptions(options)
     if options.activeCollectors then
         local collectorsList = {}
-        for key, value in pairs(options.activeCollectors) do
+        for _, value in pairs(options.activeCollectors) do
             collectorsList[value] = true
         end
         activeCollectors = collectorsList

--- a/lua/LUA/ak/data/DataWebConnector.lua
+++ b/lua/LUA/ak/data/DataWebConnector.lua
@@ -5,8 +5,7 @@ local DataWebConnector = {}
 function DataWebConnector.registerJsonCollectors(activeCollectors)
     local all = true
     if activeCollectors then
-        if next(activeCollectors) == nil then -- empty list
-        else
+        if next(activeCollectors) ~= nil then -- not empty list
             all = false
         end
     end

--- a/lua/LUA/ak/data/DataWebConnector.lua
+++ b/lua/LUA/ak/data/DataWebConnector.lua
@@ -1,8 +1,8 @@
 print("Load ak.data.DataWebConnector ...")
 local ServerController = require("ak.io.ServerController")
-local CoreWebConnector = {}
+local DataWebConnector = {}
 
-function CoreWebConnector.registerJsonCollectors()
+function DataWebConnector.registerJsonCollectors()
     ServerController.addJsonCollector(require("ak.data.DataSlotsJsonCollector"))
     ServerController.addJsonCollector(require("ak.data.SignalJsonCollector"))
     ServerController.addJsonCollector(require("ak.data.SwitchJsonCollector"))
@@ -11,4 +11,4 @@ function CoreWebConnector.registerJsonCollectors()
     ServerController.addJsonCollector(require("ak.data.TrainsAndTracksJsonCollector"))
 end
 
-return CoreWebConnector
+return DataWebConnector

--- a/lua/LUA/ak/data/DataWebConnector.lua
+++ b/lua/LUA/ak/data/DataWebConnector.lua
@@ -2,13 +2,33 @@ print("Load ak.data.DataWebConnector ...")
 local ServerController = require("ak.io.ServerController")
 local DataWebConnector = {}
 
-function DataWebConnector.registerJsonCollectors()
-    ServerController.addJsonCollector(require("ak.data.DataSlotsJsonCollector"))
-    ServerController.addJsonCollector(require("ak.data.SignalJsonCollector"))
-    ServerController.addJsonCollector(require("ak.data.SwitchJsonCollector"))
-    ServerController.addJsonCollector(require("ak.data.StructureJsonCollector"))
-    ServerController.addJsonCollector(require("ak.data.TimeJsonCollector"))
-    ServerController.addJsonCollector(require("ak.data.TrainsAndTracksJsonCollector"))
+function DataWebConnector.registerJsonCollectors(activeCollectors)
+    local all = true
+    if activeCollectors then
+        if next(activeCollectors) == nil then -- empty list
+        else
+            all = false
+        end
+    end
+
+    if all or activeCollectors["ak.data.DataSlotsJsonCollector"] then
+        ServerController.addJsonCollector(require("ak.data.DataSlotsJsonCollector"))
+    end
+    if all or activeCollectors["ak.data.SignalJsonCollector"] then
+        ServerController.addJsonCollector(require("ak.data.SignalJsonCollector"))
+    end
+    if all or activeCollectors["ak.data.SwitchJsonCollector"] then
+        ServerController.addJsonCollector(require("ak.data.SwitchJsonCollector"))
+    end
+    if all or activeCollectors["ak.data.StructureJsonCollector"] then
+        ServerController.addJsonCollector(require("ak.data.StructureJsonCollector"))
+    end
+    if all or activeCollectors["ak.data.TimeJsonCollector"] then
+        ServerController.addJsonCollector(require("ak.data.TimeJsonCollector"))
+    end
+    if all or activeCollectors["ak.data.TrainsAndTracksJsonCollector"] then
+        ServerController.addJsonCollector(require("ak.data.TrainsAndTracksJsonCollector"))
+    end
 end
 
 return DataWebConnector

--- a/lua/LUA/ak/data/StructureJsonCollector.lua
+++ b/lua/LUA/ak/data/StructureJsonCollector.lua
@@ -33,7 +33,7 @@ function StructureJsonCollector.initialize()
             local structure = {}
             structure.name = name
 
-            local hasPos, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
+            local _, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
             local _, modelType = EEPStructureGetModelType(name)
             local EEPStructureModelTypeText = {
                 [16] = "Gleis/Gleisobjekt",

--- a/lua/LUA/ak/data/StructureJsonCollector.lua
+++ b/lua/LUA/ak/data/StructureJsonCollector.lua
@@ -38,7 +38,7 @@ function StructureJsonCollector.initialize()
             local EEPStructureModelTypeText = {
                 [16] = "Gleis/Gleisobjekt",
                 [17] = "Schiene/Gleisobjekt",
-                [18] = "Straﬂe/Gleisobjekt",
+                [18] = "Strasse/Gleisobjekt", -- avoid German Umlaute
                 [19] = "Sonstiges/Gleisobjekt",
                 [22] = "Immobilie",
                 [23] = "Landschaftselement/Fauna",

--- a/lua/LUA/ak/data/StructureJsonCollector.lua
+++ b/lua/LUA/ak/data/StructureJsonCollector.lua
@@ -33,26 +33,26 @@ function StructureJsonCollector.initialize()
             local structure = {}
             structure.name = name
 
-            local _, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
+            local hasPos, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
             local _, modelType = EEPStructureGetModelType(name)
-            -- local EEPStructureModelTypeText = {
-            --     -- not used yet
-            --     ["16"] = "Gleis/Gleisobjekt",
-            --     ["17"] = "Schiene/Gleisobjekt",
-            --     ["18"] = "Straﬂe/Gleisobjekt",
-            --     ["19"] = "Sonstiges/Gleisobjekt",
-            --     ["22"] = "Immobilie",
-            --     ["23"] = "Landschaftselement/Fauna",
-            --     ["24"] = "Landschaftselement/Flora",
-            --     ["25"] = "Landschaftselement/Terra",
-            --     ["38"] = "Landschaftselement/Instancing"
-            -- }
+            local EEPStructureModelTypeText = {
+                [16] = "Gleis/Gleisobjekt",
+                [17] = "Schiene/Gleisobjekt",
+                [18] = "Straﬂe/Gleisobjekt",
+                [19] = "Sonstiges/Gleisobjekt",
+                [22] = "Immobilie",
+                [23] = "Landschaftselement/Fauna",
+                [24] = "Landschaftselement/Flora",
+                [25] = "Landschaftselement/Terra",
+                [38] = "Landschaftselement/Instancing"
+            }
             local _, tag = EEPStructureGetTagText(name)
 
-            structure.pos_x = pos_x and string.format("%.2f", pos_x) or 0
-            structure.pos_y = pos_y and string.format("%.2f", pos_y) or 0
-            structure.pos_z = pos_z and string.format("%.2f", pos_z) or 0
+            structure.pos_x = pos_x and tonumber(string.format("%.2f", pos_x)) or 0
+            structure.pos_y = pos_y and tonumber(string.format("%.2f", pos_y)) or 0
+            structure.pos_z = pos_z and tonumber(string.format("%.2f", pos_z)) or 0
             structure.modelType = modelType or 0
+            structure.modelTypeText = EEPStructureModelTypeText[modelType] or ""
             structure.tag = tag or ""
             table.insert(structures, structure)
         end

--- a/lua/LUA/ak/data/TrainsAndTracksJsonCollector.lua
+++ b/lua/LUA/ak/data/TrainsAndTracksJsonCollector.lua
@@ -245,8 +245,8 @@ local function updateTracksBy(besetztFunktion, trackType)
                     [5] = "Diesellok",
                     [6] = "Triebwagen",
                     [7] = "U- oder S-Bahn",
-                    [8] = "Straßenbahn",
-                    [9] = "Güterwaggon",
+                    [8] = "Strassenbahn", -- avoid German Umlaute
+                    [9] = "Gueterwaggon", -- avoid German Umlaute
                     [10] = "Personenwaggon",
                     [11] = "Luftfahrzeug",
                     [12] = "Maschine",

--- a/lua/LUA/ak/data/TrainsAndTracksJsonCollector.lua
+++ b/lua/LUA/ak/data/TrainsAndTracksJsonCollector.lua
@@ -190,7 +190,7 @@ local function updateTracksBy(besetztFunktion, trackType)
 
     for trainName, train in pairs(trains) do
         -- Store trains
-        local haveSpeed, speed = EEPGetTrainSpeed(trainName) -- EEP 11.0
+        local _, speed = EEPGetTrainSpeed(trainName) -- EEP 11.0
         local haveRoute, route = EEPGetTrainRoute(trainName) -- EEP 11.2 Plugin 2
 
         local rollingStockCount = EEPGetRollingstockItemsCount(trainName) -- EEP 13.2 Plug-In 2

--- a/lua/LUA/ak/data/TrainsAndTracksJsonCollector.lua
+++ b/lua/LUA/ak/data/TrainsAndTracksJsonCollector.lua
@@ -8,6 +8,8 @@ local MAX_TRACKS = 50000
 local data = {}
 local tracks = {}
 
+--- Store runtime information
+-- @author Frank Buchholz
 function storeRunTime(group, time)
     -- collect and sum runtime date, needs rework
     if not data["runtime"] then
@@ -23,7 +25,23 @@ function storeRunTime(group, time)
     local runtime = data["runtime"][group]
     runtime.count = runtime.count + 1
     runtime.time = runtime.time + time
-    -- data["times"][1][group] = runtime
+end
+
+--- Indirect call of EEP function (or any other function) including time measurement
+-- @author Frank Buchholz
+function executeAndStoreRunTime(func, group, ...)
+    if not func then
+        return
+    end
+
+    local t0 = os.clock()
+
+    local result = {func(...)}
+
+    local t1 = os.clock()
+    storeRunTime(group, t1 - t0)
+
+    return table.unpack(result)
 end
 
 --- Create dummy functions for EEP functions which are not yet available depending of the version of EEP
@@ -39,18 +57,7 @@ EEPGetSignalTrainName = EEPGetSignalTrainName or function()
 --EEPGetRollingstockItemsCount = EEPGetRollingstockItemsCount  or function () return end -- EEP 13.2 Plug-In 2
 local _EEPGetRollingstockItemsCount = EEPGetRollingstockItemsCount
 local function EEPGetRollingstockItemsCount(...)
-    if not _EEPGetRollingstockItemsCount then
-        return
-    end
-
-    local t0 = os.clock()
-
-    local result = {_EEPGetRollingstockItemsCount(...)}
-
-    local t1 = os.clock()
-    storeRunTime("EEPGetRollingstockItemsCount", t1 - t0)
-
-    return table.unpack(result)
+    return executeAndStoreRunTime(_EEPGetRollingstockItemsCount, "EEPGetRollingstockItemsCount", ...)
 end
 
 EEPGetRollingstockItemName = EEPGetRollingstockItemName or function()
@@ -79,21 +86,14 @@ EEPRollingstockGetTagText = EEPRollingstockGetTagText or function()
         return
     end -- EEP 14.2
 
--- Redefine function from EEP 11.0 to collect run time data
+-- Redefine functions from EEP 11.0 to collect run time data
 local _EEPGetTrainSpeed = EEPGetTrainSpeed
 local function EEPGetTrainSpeed(...)
-    if not EEPGetTrainSpeed then
-        return
-    end
-
-    local t0 = os.clock()
-
-    local result = {_EEPGetTrainSpeed(...)}
-
-    local t1 = os.clock()
-    storeRunTime("EEPGetTrainSpeed", t1 - t0)
-
-    return table.unpack(result)
+    return executeAndStoreRunTime(_EEPGetTrainSpeed, "EEPGetTrainSpeed", ...)
+end
+local _EEPGetRollingstockItemName = EEPGetRollingstockItemName
+local function EEPGetRollingstockItemName(...)
+    return executeAndStoreRunTime(_EEPGetRollingstockItemName, "EEPGetRollingstockItemName", ...)
 end
 
 --- Register EEP tracks.
@@ -200,15 +200,14 @@ local function updateTracksBy(besetztFunktion, trackType)
             id = trainName,
             route = haveRoute and route or "",
             rollingStockCount = rollingStockCount or 0,
-            length = trainLength or 0
+            length = trainLength or 0,
         }
 
         table.insert(data[trainList], currentTrain)
         -- data[trainList][tostring(currentTrain.id)] = currentTrain
         local trainsInfo = {
             id = trainName,
-            speed = haveSpeed and speed or --string.format("%.2f", speed)
-                0,
+            speed = tonumber(string.format("%.4f", speed or 0)),
             onTrackId = train.onTrack,
             occupiedTacks = train.occupiedTacks
         }
@@ -238,24 +237,23 @@ local function updateTracksBy(besetztFunktion, trackType)
                 -- EEP 14.2
 
                 local _, modelType = EEPRollingstockGetModelType(rollingStockName) -- EEP 14.2
-                -- local EEPRollingstockModelTypeText = {
-                --     -- not used yet
-                --     ["1"] = "Tenderlok",
-                --     ["2"] = "Schlepptenderlok",
-                --     ["3"] = "Tender",
-                --     ["4"] = "Elektrolok",
-                --     ["5"] = "Diesellok",
-                --     ["6"] = "Triebwagen",
-                --     ["7"] = "U- oder S-Bahn",
-                --     ["8"] = "Straßenbahn",
-                --     ["9"] = "Güterwaggon",
-                --     ["10"] = "Personenwaggon",
-                --     ["11"] = "Luftfahrzeug",
-                --     ["12"] = "Maschine",
-                --     ["13"] = "Wasserfahrzeug",
-                --     ["14"] = "LKW",
-                --     ["15"] = "PKW"
-                -- }
+                local EEPRollingstockModelTypeText = {
+                    [1] = "Tenderlok",
+                    [2] = "Schlepptenderlok",
+                    [3] = "Tender",
+                    [4] = "Elektrolok",
+                    [5] = "Diesellok",
+                    [6] = "Triebwagen",
+                    [7] = "U- oder S-Bahn",
+                    [8] = "Straßenbahn",
+                    [9] = "Güterwaggon",
+                    [10] = "Personenwaggon",
+                    [11] = "Luftfahrzeug",
+                    [12] = "Maschine",
+                    [13] = "Wasserfahrzeug",
+                    [14] = "LKW",
+                    [15] = "PKW"
+                }
 
                 local _, tag = EEPRollingstockGetTagText(rollingStockName) -- EEP 14.2
 
@@ -265,29 +263,31 @@ local function updateTracksBy(besetztFunktion, trackType)
                     positionInTrain = i,
                     couplingFront = couplingFront,
                     couplingRear = couplingRear,
-                    length = length or -1, --string.format("%.2f", length),
+                    length = tonumber(string.format("%.2f", length or -1)),
                     propelled = propelled or true,
                     trackSystem = trackSystem or -1,
                     modelType = modelType or -1,
+                    modelTypeText = EEPRollingstockModelTypeText[modelType] or "",
                     tag = tag or ""
                 }
                 if hasPos then
-                    currentRollingStock.PosX = PosX
-                    currentRollingStock.PosY = PosY
-                    currentRollingStock.PosZ = PosZ
+                    currentRollingStock.PosX = tonumber(PosX)
+                    currentRollingStock.PosY = tonumber(PosY)
+                    currentRollingStock.PosZ = tonumber(PosZ)
                 end
                 table.insert(data[rollingStockList], currentRollingStock)
                 -- data[rollingStockList][currentRollingStock.name] = currentRollingStock
                 local rollingStockInfo = {
                     name = rollingStockName,
                     trackId = trackId or -1,
-                    trackDistance = trackDistance or -1, --string.format("%.2f", trackDistance),
+                    trackDistance = tonumber(string.format("%.2f", trackDistance or -1)),
                     trackDirection = trackDirection or -1
                 }
                 table.insert(data[rollingStockInfos], rollingStockInfo)
             -- data[rollingStockInfos][tostring(rollingStockInfo.name)] = rollingStockInfo
             end
         end
+        currentTrain.length = tonumber(string.format("%.2f", currentTrain.length or 0))
     end
 end
 
@@ -313,6 +313,9 @@ function TrainsAndTracksJsonCollector.collectData()
     if not enabled then
         return
     end
+
+    -- reset runtime data
+    data["runtime"] = {}
 
     if not initialized then
         TrainsAndTracksJsonCollector.initialize()

--- a/lua/LUA/ak/io/ServerController.lua
+++ b/lua/LUA/ak/io/ServerController.lua
@@ -22,6 +22,13 @@ ServerController.programVersion = "0.9.0"
 -- false: Update json file without checking if the EEP-Web Server is ready
 ServerController.checkServerStatus = true
 
+-- List of collectors which should be active (default = all)
+-- Example: { ["ak.core.VersionJsonCollector"] = true, ["ak.data.TrainsAndTracksJsonCollector"] = true, }
+ServerController.activeCollectors = {}
+-- List of entries which should be active (default = all)
+-- Example: { ["api-entries"] = true, ["eep-version"] = true, }
+ServerController.activeEntries = {}
+
 local registeredJsonCollectors = {}
 local collectedData = {}
 local checksum = 0
@@ -113,20 +120,25 @@ function ServerController.addJsonCollector(...)
         assert(
             jsonCollector.initialize and type(jsonCollector.initialize) == "function",
             --"Das Modul muss eine Funktion initialize() besitzen"
-            string.format("Module %s must have a function initialize()", jsonCollector.name)
+            string.format("jsonCollector %s must have a function initialize()", jsonCollector.name)
         )
         assert(
             jsonCollector.collectData and type(jsonCollector.collectData) == "function",
             --"Das Modul muss eine Funktion collectData() besitzen"
-            string.format("Module %s must have a function collectData()", jsonCollector.name)
+            string.format("jsonCollector %s must have a function collectData()", jsonCollector.name)
         )
 
-        -- Remember the jsonCollector by it's name
-        print(string.format("ServerController.addJsonCollector(%s)", jsonCollector.name))
-        registeredJsonCollectors[jsonCollector.name] = jsonCollector
+        if next(ServerController.activeCollectors) == nil -- empty list
+          or ServerController.activeCollectors[jsonCollector.name] then
+            -- Remember the jsonCollector by it's name
+            print(string.format("ServerController.addJsonCollector(%s)", jsonCollector.name))
+            registeredJsonCollectors[jsonCollector.name] = jsonCollector
 
-        if initialized then
-            initializeJsonCollector(jsonCollector)
+            if initialized then
+                initializeJsonCollector(jsonCollector)
+            end
+        else    
+            print(string.format("ServerController.addJsonCollector(%s) not activated", jsonCollector.name))
         end
     end
 end
@@ -138,8 +150,13 @@ function collectAndWriteData(printFirstTime, modulus)
     -- add statistical data
     local t1 = os.clock()
     local orderedKeys = {}
-    for key in pairs(collectedData) do
-        table.insert(orderedKeys, key)
+    local exportData = {}
+    for key, value in pairs(collectedData) do
+        if next(ServerController.activeEntries) == nil -- empty list
+          or ServerController.activeEntries[key] then
+            exportData[key] = value
+            table.insert(orderedKeys, key)
+        end 
     end
     table.sort(orderedKeys)
     fillApiEntriesV1(orderedKeys)
@@ -147,7 +164,7 @@ function collectAndWriteData(printFirstTime, modulus)
     -- write file
     local t2 = os.clock()
 
-    local content = json.encode(collectedData, {keyorder = orderedKeys})
+    local content = json.encode(exportData, {keyorder = orderedKeys})
 
     local t3 = os.clock()
     AkWebServerIo.updateJsonFile(content)

--- a/lua/LUA/ak/io/ServerController.lua
+++ b/lua/LUA/ak/io/ServerController.lua
@@ -22,9 +22,6 @@ ServerController.programVersion = "0.9.0"
 -- false: Update json file without checking if the EEP-Web Server is ready
 ServerController.checkServerStatus = true
 
--- List of collectors which should be active (default = all)
--- Example: { ["ak.core.VersionJsonCollector"] = true, ["ak.data.TrainsAndTracksJsonCollector"] = true, }
-ServerController.activeCollectors = {}
 -- List of entries which should be active (default = all)
 -- Example: { ["api-entries"] = true, ["eep-version"] = true, }
 ServerController.activeEntries = {}
@@ -128,17 +125,12 @@ function ServerController.addJsonCollector(...)
             string.format("jsonCollector %s must have a function collectData()", jsonCollector.name)
         )
 
-        if next(ServerController.activeCollectors) == nil -- empty list
-          or ServerController.activeCollectors[jsonCollector.name] then
-            -- Remember the jsonCollector by it's name
-            print(string.format("ServerController.addJsonCollector(%s)", jsonCollector.name))
-            registeredJsonCollectors[jsonCollector.name] = jsonCollector
+        -- Remember the jsonCollector by it's name
+        print(string.format("ServerController.addJsonCollector(%s)", jsonCollector.name))
+        registeredJsonCollectors[jsonCollector.name] = jsonCollector
 
-            if initialized then
-                initializeJsonCollector(jsonCollector)
-            end
-        else    
-            print(string.format("ServerController.addJsonCollector(%s) not activated", jsonCollector.name))
+        if initialized then
+            initializeJsonCollector(jsonCollector)
         end
     end
 end
@@ -156,7 +148,7 @@ function collectAndWriteData(printFirstTime, modulus)
           or ServerController.activeEntries[key] then
             exportData[key] = value
             table.insert(orderedKeys, key)
-        end 
+        end
     end
     table.sort(orderedKeys)
     fillApiEntriesV1(orderedKeys)


### PR DESCRIPTION
- Neue Funktionen ModuleRegistry.registerCollectors und ModuleRegistry.setActiveEntries mit der die zu exportierenden Daten fein ausgewählt werden können.
- Elegantere Möglichkeit die Laufzeit von EEP-Funktionen zu messen (z.Z. allerdings nur in TrainsAndTracksJsonCollector)
- Zahlen mit 2 (Position, Länge) bzw. 4 (Geschwindigkeit) Nachkommastellen
- Ausgabe von modelTypeText für Rollmaterialien und Immobilien