### PR TITLE
fix developer doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Die bereitgestellte Bibliothek übernimmt für Dich die _Steuerung des Verkehrs_
 
 * [Fehler gefunden, Verbesserungsvorschläge?](CONTRIBUTING.md) <br>So kannst Du zum Projekt beitragen
 
-* So kannst Du die [Entwicklungsumgebung einrichten](scripts/README)
+* So kannst Du die [Entwicklungsumgebung einrichten](scripts/README.md)
 
 ## Was ist EEP
 


### PR DESCRIPTION
The link to the developer doc introduced in https://github.com/Andreas-Kreuz/ak-lua-bibliothek-fuer-eep/pull/61 didn't work.