### PR TITLE
EEP 16.1 functions

### DIFF
--- a/lua/LUA/ak/data/StructureJsonCollector.lua
+++ b/lua/LUA/ak/data/StructureJsonCollector.lua
@@ -16,7 +16,10 @@ local EEPStructureGetModelType = EEPStructureGetModelType or function()
 local EEPStructureGetTagText = EEPStructureGetTagText or function()
         return
     end -- EEP 14.2
-local EEPStructureGetRotation = EEPStructureGetRotation or function() -- (not used yet)
+
+--- Ermittelt die Ausrichtung der Immobilie/des Landschaftselementes in Grad (°)
+-- OK, RotX, RotY, RotZ = EEPStructureGetRotation("#aunnel")
+local EEPStructureGetRotation = EEPStructureGetRotation or function()
         return
     end -- EEP 16.1
 
@@ -37,11 +40,12 @@ function StructureJsonCollector.initialize()
             structure.name = name
 
             local _, pos_x, pos_y, pos_z = EEPStructureGetPosition(name)
+            local _, rot_x, rot_y, rot_z = EEPStructureGetRotation(name)
             local _, modelType = EEPStructureGetModelType(name)
             local EEPStructureModelTypeText = {
                 [16] = "Gleis/Gleisobjekt",
                 [17] = "Schiene/Gleisobjekt",
-                [18] = "Strasse/Gleisobjekt", -- avoid German Umlaute
+                [18] = "Straße/Gleisobjekt",
                 [19] = "Sonstiges/Gleisobjekt",
                 [22] = "Immobilie",
                 [23] = "Landschaftselement/Fauna",
@@ -54,6 +58,9 @@ function StructureJsonCollector.initialize()
             structure.pos_x = pos_x and tonumber(string.format("%.2f", pos_x)) or 0
             structure.pos_y = pos_y and tonumber(string.format("%.2f", pos_y)) or 0
             structure.pos_z = pos_z and tonumber(string.format("%.2f", pos_z)) or 0
+            structure.rot_x = rot_x and tonumber(string.format("%.2f", rot_x)) or 0
+            structure.rot_y = rot_y and tonumber(string.format("%.2f", rot_y)) or 0
+            structure.rot_z = rot_z and tonumber(string.format("%.2f", rot_z)) or 0
             structure.modelType = modelType or 0
             structure.modelTypeText = EEPStructureModelTypeText[modelType] or ""
             structure.tag = tag or ""

--- a/lua/LUA/ak/data/StructureJsonCollector.lua
+++ b/lua/LUA/ak/data/StructureJsonCollector.lua
@@ -7,15 +7,18 @@ StructureJsonCollector.name = "ak.data.StructureJsonCollector"
 local MAX_STRUCTURES = 50000
 local structures = {}
 
-EEPStructureGetPosition = EEPStructureGetPosition or function()
+local EEPStructureGetPosition = EEPStructureGetPosition or function()
         return
     end -- EEP 14.2
-EEPStructureGetModelType = EEPStructureGetModelType or function()
+local EEPStructureGetModelType = EEPStructureGetModelType or function()
         return
     end -- EEP 14.2
-EEPStructureGetTagText = EEPStructureGetTagText or function()
+local EEPStructureGetTagText = EEPStructureGetTagText or function()
         return
     end -- EEP 14.2
+local EEPStructureGetRotation = EEPStructureGetRotation or function() -- (not used yet)
+        return
+    end -- EEP 16.1
 
 function StructureJsonCollector.initialize()
     if not enabled or initialized then

--- a/lua/LUA/ak/data/TrackCollector.lua
+++ b/lua/LUA/ak/data/TrackCollector.lua
@@ -318,7 +318,7 @@ function TrackCollector:updateTrain(trainName)
         id = trainName,
         route = haveRoute and route or "",
         rollingStockCount = rollingStockCount or 0,
-        length = trainLength or 0
+        length = tonumber(string.format("%.2f", trainLength or 0)),
     }
     self.trains[trainName] = currentTrain
 

--- a/lua/LUA/ak/data/TrackCollector.lua
+++ b/lua/LUA/ak/data/TrackCollector.lua
@@ -132,40 +132,40 @@ local EEPRollingstockGetTagText = EEPRollingstockGetTagText or function()
 
 
 --- Ermittelt die Position des Rollmaterials im EEP-Koordinatensystem in Meter (m).
---  OK, PosX, PosY, PosZ = EEPRollingstockGetPosition(“#Fahrzeug”)
+--  OK, PosX, PosY, PosZ = EEPRollingstockGetPosition("#Fahrzeug")
 local EEPRollingstockGetPosition = EEPRollingstockGetPosition or function()
         return
     end -- EEP 16.1
 
 --- Ermittelt, ob der Haken eines bestimmten Rollmaterials an oder ausgeschaltet ist 	
--- OK, Status = EEPRollingstockGetHook(“#Kranwagen”)
+-- OK, Status = EEPRollingstockGetHook("#Kranwagen")
 -- Haken aus = 0, an = 1, in Betrieb = 3 
 local EEPRollingstockGetHook = EEPRollingstockGetHook or function() -- (not used yet)
         return
     end -- EEP 16.1
 
 --- Ermittelt das Verhalten von Gütern am Kranhaken eines Rollmaterials
---  OK, Status = EEPRollingstockGetHookGlue(”#Kranwagen”)
+--  OK, Status = EEPRollingstockGetHookGlue("#Kranwagen")
 -- Güterhaken aus = 0, an = 1, in Benutzung = 3 
 local EEPRollingstockGetHookGlue = EEPRollingstockGetHookGlue or function() -- (not used yet)
         return
     end -- EEP 16.1
 
 --- Ermittelt die zurückgelegte Strecke des Rollmaterials in Meter (m)
---  OK, Mileage = EEPRollingstockGetMileage(“#Fahrzeug”)
+--  OK, Mileage = EEPRollingstockGetMileage("#Fahrzeug")
 local EEPRollingstockGetMileage = EEPRollingstockGetMileage or function()
         return
     end -- EEP 16.1
 
 --- Ermittelt, ob der Rauch des benannten Rollmaterials, an- oder ausgeschaltet ist.
--- OK, Status = EEPRollingstockGetSmoke(“#Fahrzeug”)
+-- OK, Status = EEPRollingstockGetSmoke("#Fahrzeug")
 -- aus = 0, angeschaltet = 1
 local EEPRollingstockGetSmoke = EEPRollingstockGetSmoke or function() -- (not used yet)
         return
     end -- EEP 16.1
 
 --- Ermittelt die Ausrichtung des Ladegutes in Grad (°)
--- OK, RotX, RotY, RotZ = EEPGoodsGetRotation(“#Container”)
+-- OK, RotX, RotY, RotZ = EEPGoodsGetRotation("#Container")
 local EEPGoodsGetRotation = EEPGoodsGetRotation or function() -- (not used yet)
         return
     end -- EEP 16.1

--- a/lua/LUA/ak/data/TrackCollector.lua
+++ b/lua/LUA/ak/data/TrackCollector.lua
@@ -25,8 +25,8 @@ local EEPRollingstockModelTypeText = {
     [5] = "Diesellok",
     [6] = "Triebwagen",
     [7] = "U- oder S-Bahn",
-    [8] = "Strassenbahn", -- avoid German Umlaute
-    [9] = "Gueterwaggon", -- avoid German Umlaute
+    [8] = "Straßenbahn", -- German Umlaute are ok if stored as UTF-8
+    [9] = "Güterwaggon", -- German Umlaute are ok if stored as UTF-8
     [10] = "Personenwaggon",
     [11] = "Luftfahrzeug",
     [12] = "Maschine",
@@ -90,29 +90,136 @@ local function EEPGetRollingstockItemsCount(...)
     return executeAndStoreRunTime(_EEPGetRollingstockItemsCount, "EEPGetRollingstockItemsCount", ...)
 end
 
+-- Ermittelt die Gesamtlänge des angegebenen Zuges.
 local EEPGetTrainLength = EEPGetTrainLength or function()
         return
     end -- EEP 15.1 Plug-In 1
 
-local EEPRollingstockGetPosition = EEPRollingstockGetPosition or function()
+-- Ermittelt, welches Fahrzeug derzeit im Steuerdialog ausgewählt ist.
+local EEPRollingstockGetActive = EEPRollingstockGetActive or function() -- (not used yet)
         return
-    end -- EEP 16.1
+    end -- EEP 15.1 Plug-In 1
+
+-- Ermittelt, welcher Zug derzeit im Steuerdialog ausgewählt ist.
+local EEPGetTrainActive = EEPGetTrainActive or function() -- (not used yet)
+        return
+    end -- EEP 15.1 Plug-In 1
+
+-- Ermittelt, welche relative Ausrichtung das angegebene Fahrzeug im Zugverband hat.
+local EEPRollingstockGetOrientation = EEPRollingstockGetOrientation or function() -- (not used yet)
+        return
+    end -- EEP 15.1 Plug-In 1
+
 local EEPRollingstockGetLength = EEPRollingstockGetLength or function()
         return
     end -- EEP 14.2
+
 local EEPRollingstockGetMotor = EEPRollingstockGetMotor or function()
         return
     end -- EEP 14.2
+
 local EEPRollingstockGetTrack = EEPRollingstockGetTrack or function()
         return
     end -- EEP 14.2
+
 local EEPRollingstockGetModelType = EEPRollingstockGetModelType or function()
         return
     end -- EEP 14.2
-EEPRollingstockGetTagText = EEPRollingstockGetTagText or function()
+
+local EEPRollingstockGetTagText = EEPRollingstockGetTagText or function()
         return
     end -- EEP 14.2
 
+
+--- Ermittelt die Position des Rollmaterials im EEP-Koordinatensystem in Meter (m).
+--  OK, PosX, PosY, PosZ = EEPRollingstockGetPosition(“#Fahrzeug”)
+local EEPRollingstockGetPosition = EEPRollingstockGetPosition or function()
+        return
+    end -- EEP 16.1
+
+--- Ermittelt, ob der Haken eines bestimmten Rollmaterials an oder ausgeschaltet ist 	
+-- OK, Status = EEPRollingstockGetHook(“#Kranwagen”)
+-- Haken aus = 0, an = 1, in Betrieb = 3 
+local EEPRollingstockGetHook = EEPRollingstockGetHook or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt das Verhalten von Gütern am Kranhaken eines Rollmaterials
+--  OK, Status = EEPRollingstockGetHookGlue(”#Kranwagen”)
+-- Güterhaken aus = 0, an = 1, in Benutzung = 3 
+local EEPRollingstockGetHookGlue = EEPRollingstockGetHookGlue or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die zurückgelegte Strecke des Rollmaterials in Meter (m)
+--  OK, Mileage = EEPRollingstockGetMileage(“#Fahrzeug”)
+local EEPRollingstockGetMileage = EEPRollingstockGetMileage or function()
+        return
+    end -- EEP 16.1
+
+--- Ermittelt, ob der Rauch des benannten Rollmaterials, an- oder ausgeschaltet ist.
+-- OK, Status = EEPRollingstockGetSmoke(“#Fahrzeug”)
+-- aus = 0, angeschaltet = 1
+local EEPRollingstockGetSmoke = EEPRollingstockGetSmoke or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die Ausrichtung des Ladegutes in Grad (°)
+-- OK, RotX, RotY, RotZ = EEPGoodsGetRotation(“#Container”)
+local EEPGoodsGetRotation = EEPGoodsGetRotation or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+	
+-- To be used in another modules:
+
+--- Ermittelt die aktuelle Position der Kamera
+-- OK, PosX, PosY, PosZ = EEPGetCameraPosition()
+local EEPGetCameraPosition = EEPGetCameraPosition or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die aktuelle Ausrichtung einer Kamera.
+-- OK, RotX, RotY, RotZ = EEPGetCameraRotation()
+local EEPGetCameraRotation = EEPGetCameraRotation or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die Windstärke in Prozent (%)
+--  OK, WindIntensity = EEPGetWindIntensity()
+local EEPGetWindIntensity = EEPGetWindIntensity or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die Niederschlagintensität in Prozent (%)
+--  OK, RainIntensity = EEPGetRainIntensity()
+local EEPGetRainIntensity = EEPGetRainIntensity or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die Schneeintensitä in Prozent (%)
+--  OK, SnowIntensity = EEPGetSnowIntensity()
+local EEPGetSnowIntensity = EEPGetSnowIntensity or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die Hagelintensität in Prozent (%)
+-- OK, HailIntensity = EEPGetHailIntensity()
+local EEPGetHailIntensity = EEPGetHailIntensity or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt die Nebelintensität in Prozent (%)
+-- OK, FogIntensity = EEPGetFogIntensity()
+local EEPGetFogIntensity = EEPGetFogIntensity or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+
+--- Ermittelt der Wolkenanteil in Prozent (%)
+-- OK, CloudIntensity = EEPGetCloudIntensity()
+local EEPGetCloudIntensity = EEPGetCloudIntensity or function() -- (not used yet)
+        return
+    end -- EEP 16.1
+	
 -- Redefine functions from EEP 11.0 to collect run time data
 local _EEPGetTrainSpeed = EEPGetTrainSpeed
 local function EEPGetTrainSpeed(...)
@@ -242,7 +349,7 @@ function TrackCollector:updateTrainInfo(trainName, trackId)
 end
 
 function TrackCollector:updateRollingStock(rollingStockName, currentTrain, positionInTrain)
-    -- 1 Kupplung scharf, 2 Absto�en, 3 Gekuppelt
+    -- 1 Kupplung scharf, 2 Abstoßen, 3 Gekuppelt
     local _, couplingFront = EEPRollingstockGetCouplingFront(rollingStockName) -- EEP 11.0
     local _, couplingRear = EEPRollingstockGetCouplingRear(rollingStockName) -- EEP 11.0
 
@@ -261,7 +368,7 @@ function TrackCollector:updateRollingStock(rollingStockName, currentTrain, posit
         propelled = propelled or true,
         modelType = modelType or -1,
         modelTypeText = EEPRollingstockModelTypeText[modelType] or "",
-        tag = tag or ""
+        tag = tag or "",
     }
 
     -- Save
@@ -273,6 +380,7 @@ function TrackCollector:updateRollingStockInfo(rollingStockName)
     local _, trackId, trackDistance, trackDirection, trackSystem = EEPRollingstockGetTrack(rollingStockName)
     -- EEP 14.2
     local hasPos, PosX, PosY, PosZ = EEPRollingstockGetPosition(rollingStockName) -- EEP 16.1
+	local hasMileage, mileage = EEPRollingstockGetMileage(rollingStockName) -- EEP 16.1
 
     local rollingStockInfo = {
         name = rollingStockName,
@@ -282,7 +390,8 @@ function TrackCollector:updateRollingStockInfo(rollingStockName)
         trackSystem = trackSystem or -1,
         posX = hasPos and tonumber(PosX) or -1,
         posY = hasPos and tonumber(PosY) or -1,
-        posZ = hasPos and tonumber(PosZ) or -1
+        posZ = hasPos and tonumber(PosZ) or -1,
+		mileage = hasMileage and tonumber(mileage) or -1,
     }
     self.rollingStockInfo[rollingStockName] = rollingStockInfo
 end
@@ -307,7 +416,7 @@ end
 
 function TrackCollector:reactOnTrainChanges()
     -- React to train changes from EEP
-    local _EEPOnTrainCoupling = EEPOnTrainCoupling or function()
+    local _EEPOnTrainCoupling = EEPOnTrainCoupling or function() -- EEP 14 Plug-In 1
         end
     EEPOnTrainCoupling = function(trainA, trainB, trainNew)
         -- Mark these trains as dirty, i.e. refresh their data
@@ -318,7 +427,7 @@ function TrackCollector:reactOnTrainChanges()
         return _EEPOnTrainCoupling(trainA, trainB, trainNew)
     end
 
-    local _EEPOnTrainLooseCoupling = EEPOnTrainLooseCoupling or function()
+    local _EEPOnTrainLooseCoupling = EEPOnTrainLooseCoupling or function() -- EEP 14 Plug-In 1
         end
     EEPOnTrainLooseCoupling = function(trainA, trainB, trainNew)
         -- Mark these trains as dirty, i.e. refresh their data
@@ -329,7 +438,7 @@ function TrackCollector:reactOnTrainChanges()
         return _EEPOnTrainLooseCoupling(trainA, trainB, trainNew)
     end
 
-    local _EEPOnTrainExitTrainyard = EEPOnTrainExitTrainyard or function()
+    local _EEPOnTrainExitTrainyard = EEPOnTrainExitTrainyard or function() -- EEP 14 Plug-In 1
         end
     EEPOnTrainExitTrainyard = function(depotId, trainName)
         self.dirtyTrainNames[trainName] = true


### PR DESCRIPTION
Bei der Rückschau sehe ich, dass sich doch wieder mehrere Änderungen eingeschlichen haben:
- alle neuen EEP 16.1 werden genannt und z.T. verwendet (das war der Zweck des Pull-Requests)
- EEP Functions nur lokal überladen (wie in den anderen Beispielen)
- Datei auf UTF-8 konvertiert, wodurch deutsche Umlaute genutzt werden können
- trainLength nur mit 2 Nachkommastellen ausgeben (hier hätte ich wohl einen neuen branch anlegen müssen, um einen neuen Pull-Request zu erhalten)