### PR TITLE
add support for 6 entry display model

### DIFF
--- a/lua/LUA/ak/roadline/RoadStation.lua
+++ b/lua/LUA/ak/roadline/RoadStation.lua
@@ -69,8 +69,8 @@ function RoadStation:trainArrivesIn(trainName, timeInMinutes)
     end
 
     if RoadStation.debug then
-        print(string.format("[RoadStation] %s: Planning Arrival of %s in %d min on platform %s", self.name,
-                            trainName, timeInMinutes, platform))
+        print(string.format("[RoadStation] %s: Planning Arrival of %s in %d min on platform %s", self.name, trainName,
+                            timeInMinutes, platform))
     end
 
     self.queue:push(trainName, timeInMinutes, platform)

--- a/lua/LUA/ak/roadline/RoadStationDisplayModel.lua
+++ b/lua/LUA/ak/roadline/RoadStationDisplayModel.lua
@@ -44,6 +44,12 @@ local SimpleStructure_initStation = function(displayStructure, stationName, plat
     -- EEPStructureSetTextureText(displayStructure, 24, "Steig " .. platform)
 end
 local SimpleStructure_displayEntries = function(displayStructure, stationQueueEntries, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationQueueEntries) == "table",
+           "Need 'stationQueueEntries' as table not as " .. type(stationQueueEntries))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+
     local text = {stationName, " (Steig ", platform, ")<br>"}
 
     table.insert(text, "Linie / Ziel / Minuten<br>")
@@ -87,6 +93,12 @@ local Tram_Schild_DL1_initStation = function(displayStructure, stationName, plat
 end
 
 local Tram_Schild_DL1_displayEntries = function(displayStructure, stationQueueEntries, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationQueueEntries) == "table",
+           "Need 'stationQueueEntries' as table not as " .. type(stationQueueEntries))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+
     local text = {stationName, " (Steig ", platform, ")<br>"}
 
     table.insert(text, "Linie / Ziel / Minuten<br>")
@@ -124,12 +136,13 @@ local BusHSInfo_RG3_initStation = function(displayStructure, stationName, platfo
     assert(type(stationName) == "string", "Need 'stationName' as string")
     assert(type(platform) == "string", "Need 'platform' as string")
     EEPStructureSetTextureText(displayStructure, 1, stationName)
+    EEPStructureSetTextureText(displayStructure, 4, "Steig " .. platform)
 end
 
 local BusHSInfo_RG3_displayEntries = function(displayStructure, stationQueueEntries, stationName, platform)
     assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
-    assert(type(stationQueueEntries) == "function",
-           "Need 'stationQueueEntries' as function not as " .. type(stationQueueEntries))
+    assert(type(stationQueueEntries) == "table",
+           "Need 'stationQueueEntries' as table not as " .. type(stationQueueEntries))
     assert(type(stationName) == "string", "Need 'stationName' as string")
     assert(type(platform) == "string", "Need 'platform' as string")
 end
@@ -148,10 +161,15 @@ local BusHSdfi_RG3_initStation = function(displayStructure, stationName, platfor
     EEPStructureSetTextureText(displayStructure, 5, "")
     EEPStructureSetTextureText(displayStructure, 6, "")
     EEPStructureSetTextureText(displayStructure, 7, "")
-    EEPStructureSetTextureText(displayStructure, 8, "")
 end
 
 local BusHSdfi_RG3_displayEntries = function(displayStructure, stationQueueEntries, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationQueueEntries) == "table",
+           "Need 'stationQueueEntries' as table not as " .. type(stationQueueEntries))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+
     local text = {stationName, " (Steig ", platform, ")<br>"}
 
     table.insert(text, "Linie / Ziel / Minuten<br>")
@@ -188,5 +206,112 @@ local BusHSdfi_RG3_displayEntries = function(displayStructure, stationQueueEntri
 end
 
 DisplayModel.BusHSdfi_RG3 = DisplayModel:new("BusHSdfi_RG3", BusHSdfi_RG3_initStation, BusHSdfi_RG3_displayEntries)
+
+--------------------------------------------------------------------------------------------------------------------
+-- V15NRG35023
+--------------------------------------------------------------------------------------------------------------------
+local BusHS_Tram_Info_6_RG3_initStation = function(displayStructure, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+    EEPStructureSetTextureText(displayStructure, 1, stationName)
+    EEPStructureSetTextureText(displayStructure, 2, "")
+    EEPStructureSetTextureText(displayStructure, 3, "")
+    EEPStructureSetTextureText(displayStructure, 4, "")
+    EEPStructureSetTextureText(displayStructure, 5, "")
+    EEPStructureSetTextureText(displayStructure, 6, "")
+    EEPStructureSetTextureText(displayStructure, 7, "Steig " .. platform)
+end
+
+local BusHS_Tram_Info_6_RG3_displayEntries = function(displayStructure, stationQueueEntries, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationQueueEntries) == "table",
+           "Need 'stationQueueEntries' as table not as " .. type(stationQueueEntries))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+end
+
+DisplayModel.BusHS_Tram_Info_6_RG3 = DisplayModel:new("BusHS_Tram_Info_6_RG3", BusHS_Tram_Info_6_RG3_initStation,
+                                                      BusHS_Tram_Info_6_RG3_displayEntries)
+
+local BusHS_Tram_dfi_6_RG3_initStation = function(displayStructure, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+    for i = 1, 20 do EEPStructureSetTextureText(displayStructure, i, "") end
+end
+
+local BusHS_Tram_dfi_6_RG3_displayEntries = function(displayStructure, stationQueueEntries, stationName, platform)
+    assert(type(displayStructure) == "string", "Need 'displayStructure' as string not as " .. type(displayStructure))
+    assert(type(stationQueueEntries) == "table",
+           "Need 'stationQueueEntries' as table not as " .. type(stationQueueEntries))
+    assert(type(stationName) == "string", "Need 'stationName' as string")
+    assert(type(platform) == "string", "Need 'platform' as string")
+
+    local text = {stationName, " (Steig ", platform, ")<br>"}
+
+    table.insert(text, "Linie / Ziel / Minuten<br>")
+
+    -- Set the first entry
+    local entry = stationQueueEntries[1]
+    EEPStructureSetTextureText(displayStructure, 1, entry and (entry.line .. " " .. entry.destination) or "")
+    EEPStructureSetTextureText(displayStructure, 3,
+                               (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+    EEPStructureSetTextureText(displayStructure, 7, (entry and entry.timeInMinutes > 0) and "min" or "")
+
+    -- Set the second entry
+    entry = stationQueueEntries[2]
+    EEPStructureSetTextureText(displayStructure, 2, entry and (entry.line .. " " .. entry.destination) or "")
+    EEPStructureSetTextureText(displayStructure, 4,
+                               (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+    EEPStructureSetTextureText(displayStructure, 8, (entry and entry.timeInMinutes > 0) and "min" or "")
+
+    -- Set the second entry
+    entry = stationQueueEntries[3]
+    EEPStructureSetTextureText(displayStructure, 9, entry and (entry.line .. " " .. entry.destination) or "")
+    EEPStructureSetTextureText(displayStructure, 13,
+                               (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+    EEPStructureSetTextureText(displayStructure, 17, (entry and entry.timeInMinutes > 0) and "min" or "")
+
+    -- Set the second entry
+    entry = stationQueueEntries[4]
+    EEPStructureSetTextureText(displayStructure, 10, entry and (entry.line .. " " .. entry.destination) or "")
+    EEPStructureSetTextureText(displayStructure, 14,
+                               (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+    EEPStructureSetTextureText(displayStructure, 18, (entry and entry.timeInMinutes > 0) and "min" or "")
+
+    -- Set the second entry
+    entry = stationQueueEntries[5]
+    EEPStructureSetTextureText(displayStructure, 11, entry and (entry.line .. " " .. entry.destination) or "")
+    EEPStructureSetTextureText(displayStructure, 15,
+                               (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+    EEPStructureSetTextureText(displayStructure, 19, (entry and entry.timeInMinutes > 0) and "min" or "")
+
+    -- Set the second entry
+    entry = stationQueueEntries[6]
+    EEPStructureSetTextureText(displayStructure, 12, entry and (entry.line .. " " .. entry.destination) or "")
+    EEPStructureSetTextureText(displayStructure, 16,
+                               (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+    EEPStructureSetTextureText(displayStructure, 20, (entry and entry.timeInMinutes > 0) and "min" or "")
+
+    for i = 1, 6 do
+        entry = stationQueueEntries[i]
+        table.insert(text, entry and entry.line or "")
+        table.insert(text, " / ")
+        table.insert(text, entry and entry.destination or "")
+        table.insert(text, " / ")
+        table.insert(text, (entry and entry.timeInMinutes > 0) and tostring(entry.timeInMinutes) or "")
+        table.insert(text, " ")
+        table.insert(text, (entry and entry.timeInMinutes > 0) and "min" or "")
+        table.insert(text, "<br>")
+    end
+
+    text = table.concat(text, "")
+    EEPChangeInfoStructure(displayStructure, text)
+    EEPShowInfoStructure(displayStructure, true)
+end
+
+DisplayModel.BusHS_Tram_dfi_6_RG3 = DisplayModel:new("BusHS_Tram_dfi_6_RG3", BusHS_Tram_dfi_6_RG3_initStation,
+                                                     BusHS_Tram_dfi_6_RG3_displayEntries)
 
 return DisplayModel


### PR DESCRIPTION
V15NRG35023 can now be used with roadline

```lua
sHauptbahnhof:addDisplay("#288_BusHS Tram Info_6_RG3", RoadStationDisplayModel.BusHS_Tram_Info_6_RG3, 2)
sHauptbahnhof:addDisplay("#289_BusHS Tram dfi_6_RG3", RoadStationDisplayModel.BusHS_Tram_dfi_6_RG3, 2)
```