### PR TITLE
Fix adding new trains to line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Änderungen an der Software
 
+## v.0.11.1
+
+### Lua
+
+- 🐞 Bugfix: Fügt man neue Fahrzeuge in eine Anlage ein, werden diese automatisch anhand ihrer Route der passenden
+  ÖPNV-Linie zugeordnet und es kommt nicht mehr zu einem Programmfehler.
+
 ## v.0.11.0
 
 ### Bitte beachten

--- a/lua/LUA/ak/public-transport/Line.lua
+++ b/lua/LUA/ak/public-transport/Line.lua
@@ -72,6 +72,24 @@ function Line:addSection(routeName, destination)
     return lineSegment
 end
 
+---Change the train line according to the trains route, if no line is set in the train
+---@param train Train
+local function checkLine(train)
+    if train then
+        local lineName = train:getLine()
+        local routeName = train:getRoute()
+        if not lineName then
+            for _, line in pairs(lines) do
+                for _, segment in pairs(line.lineSegments) do
+                    if segment.routeName == routeName then
+                        train:changeDestination(segment.destination, line.nr)
+                    end
+                end
+            end
+        end
+    end
+end
+
 ---
 ---@param trainName string
 ---@param station RoadStation
@@ -85,6 +103,7 @@ function Line.scheduleDeparture(trainName, station, timeInMinutes)
     local train = TrainRegistry.forName(trainName)
     local lineName = train:getLine()
     local routeName = train:getRoute()
+    checkLine(train)
     assert(type(routeName) == "string", "Need 'routeName' as string")
 
     if lineName then
@@ -115,12 +134,12 @@ function Line.trainDeparted(trainName, station)
 
     local train = TrainRegistry.forName(trainName)
     local lineName = train:getLine()
-    -- assert(type(lineName) == "string", "Need 'lineName' as string")
     local routeName = train:getRoute()
+    checkLine(train)
     assert(type(routeName) == "string", "Need 'routeName' as string")
-    station:trainLeft(trainName, train:getDestination(), train:getLine())
 
     if lineName then
+        station:trainLeft(trainName, train:getDestination(), lineName)
         local line = lines[lineName]
         if line then
             local lineSegment = line.lineSegments[routeName]

--- a/lua/LUA/ak/train/Train.lua
+++ b/lua/LUA/ak/train/Train.lua
@@ -109,6 +109,9 @@ function Train:getValue(key)
     return self.values[key]
 end
 
+---Changes line and destination of the train
+---@param destination string
+---@param line string
 function Train:changeDestination(destination, line)
     assert(type(self) == "table" and self.type == "Train", "Call this method with ':'")
     assert(type(destination) == "string", "Need 'destination' as string")


### PR DESCRIPTION
- 🐞 Bugfix: Fügt man neue Fahrzeuge in eine Anlage ein, werden diese automatisch anhand ihrer Route der passenden
  ÖPNV-Linie zugeordnet und es kommt nicht mehr zu einem Programmfehler.