### PR TITLE
EEPRollingstockGetTextureText

### DIFF
--- a/lua/LUA/ak/core/eep/EepFunctionWrapper.lua
+++ b/lua/LUA/ak/core/eep/EepFunctionWrapper.lua
@@ -30,4 +30,7 @@ EEPRollingstockGetModelType = EEPRollingstockGetModelType or function() end -- E
 
 EEPRollingstockGetTagText = EEPRollingstockGetTagText or function() end -- EEP 14.2
 
+-- Liest den Text einer beschreibbaren Fläche eines Rollmaterials aus
+EEPRollingstockGetTextureText = EEPRollingstockGetTextureText or function() end -- EEP16.3
+
 return EepFunctionWrapper

--- a/lua/LUA/ak/core/eep/EepSimulator.lua
+++ b/lua/LUA/ak/core/eep/EepSimulator.lua
@@ -5,7 +5,7 @@ if AkDebugLoad then print("Loading ak.core.eep.EepSimulator ...") end
 ------------------
 
 --- Versionsnummer von EEP.
-EEPVer = 16.1
+EEPVer = 16.3
 
 -- Der Inhalt des EEP-EreignisFensters wird geloescht
 function clearlog()
@@ -659,6 +659,7 @@ function EEPStructureGetModelType(name)
 end
 
 local tags = {structures = {}, rollingStock = {}}
+local texturesTexts = {rollingStock = {}}
 
 --- Ã„ndert den Tag-Text einer Immobilie. Jede Immobilie kann jetzt einen individuellen String von
 --- maximal 1024 Zeichen Laenge mitfuehren. Diese Strings werden mit der Anlage gespeichert und
@@ -703,7 +704,11 @@ end
 function EEPRollingstockGetTagText(name) return true, tags.rollingStock[name] end
 
 function EEPStructureSetTextureText(name, flaeche, text) return true end
-function EEPRollingstockSetTextureText(name, flaeche, text) return true end
+function EEPRollingstockSetTextureText(name, flaeche, text)
+    textutreTexts.rollingStock[name] = {}
+    textutreTexts.rollingStock[name][flaeche] = {text}
+    return true
+end
 function EEPSignalSetTextureText(id, flaeche, text) return true end
 function EEPGoodsSetTextureText(name, flaeche, text) return true end
 function EEPRailTrackSetTextureText(id, flaeche, text) return true end
@@ -824,6 +829,18 @@ function EEPRollingstockGetMileage(rollingstockName) return true, 10 end
 -- @return PosY
 -- @return PosZ
 function EEPRollingstockGetPosition(rollingstockName) return true, 100, -50, 3 end
+
+-- Liest den Text einer beschreibbaren Fläche eines Rollmaterials aus (EEP 16.3)
+-- @param rollingstockName Name des Rollmaterials
+-- @param flaeche Nummer der Fläche, welche den Text enthaelt.
+-- @return ok Rueckgabewert ist true wenn die Ausfuehrung erfolgreich war, sonst false
+-- @return textureText
+function EEPRollingstockGetTextureText(rollingstockName, fleache)
+    local textureTexts = textureTexts.rollingStock[rollingstockName] or {}
+    local textureText = textureTexts[fleache]
+    locak ok = textureText and true or false
+    return ok, textureText
+end
 
 local camera = {}
 

--- a/lua/LUA/ak/core/eep/EepSimulator.lua
+++ b/lua/LUA/ak/core/eep/EepSimulator.lua
@@ -659,7 +659,7 @@ function EEPStructureGetModelType(name)
 end
 
 local tags = {structures = {}, rollingStock = {}}
-local texturesTexts = {rollingStock = {}}
+local textureTexts = {rollingStock = {}}
 
 --- Ändert den Tag-Text einer Immobilie. Jede Immobilie kann jetzt einen individuellen String von
 --- maximal 1024 Zeichen Laenge mitfuehren. Diese Strings werden mit der Anlage gespeichert und
@@ -705,8 +705,8 @@ function EEPRollingstockGetTagText(name) return true, tags.rollingStock[name] en
 
 function EEPStructureSetTextureText(name, flaeche, text) return true end
 function EEPRollingstockSetTextureText(name, flaeche, text)
-    textutreTexts.rollingStock[name] = {}
-    textutreTexts.rollingStock[name][flaeche] = {text}
+    textureTexts.rollingStock[name] = {}
+    textureTexts.rollingStock[name][flaeche] = text
     return true
 end
 function EEPSignalSetTextureText(id, flaeche, text) return true end
@@ -838,7 +838,7 @@ function EEPRollingstockGetPosition(rollingstockName) return true, 100, -50, 3 e
 function EEPRollingstockGetTextureText(rollingstockName, fleache)
     local textureTexts = textureTexts.rollingStock[rollingstockName] or {}
     local textureText = textureTexts[fleache]
-    locak ok = textureText and true or false
+    local ok = textureText and true or false
     return ok, textureText
 end
 

--- a/lua/LUA/ak/train/RollingStock.lua
+++ b/lua/LUA/ak/train/RollingStock.lua
@@ -66,6 +66,7 @@ function RollingStock:new(o)
     local _, propelled = EEPRollingstockGetMotor(o.id) -- EEP 14.2
     local _, modelType = EEPRollingstockGetModelType(o.id) -- EEP 14.2
     local _, tag = EEPRollingstockGetTagText(o.id) -- EEP 14.2
+    local _, textureText = EEPRollingstockGetTextureText(o.id) -- EEP 16.3
 
     local _, trackId, trackDistance, trackDirection, trackSystem = EEPRollingstockGetTrack(o.id)
     -- EEP 14.2
@@ -84,6 +85,7 @@ function RollingStock:new(o)
     o.modelType = modelType or -1
     o.modelTypeText = EEPRollingstockModelTypeText[modelType] or ""
     o.tag = tag or ""
+    o.textureText = textureText or ""
     o.values = StorageUtility.parseTableFromString(tag)
     o.trackId = trackId or -1
     o.trackDistance = tonumber(string.format("%.2f", trackDistance or -1))

--- a/lua/LUA/ak/train/RollingStock.lua
+++ b/lua/LUA/ak/train/RollingStock.lua
@@ -66,7 +66,7 @@ function RollingStock:new(o)
     local _, propelled = EEPRollingstockGetMotor(o.id) -- EEP 14.2
     local _, modelType = EEPRollingstockGetModelType(o.id) -- EEP 14.2
     local _, tag = EEPRollingstockGetTagText(o.id) -- EEP 14.2
-    local _, textureText = EEPRollingstockGetTextureText(o.id) -- EEP 16.3
+    local _, textureText = EEPRollingstockGetTextureText(o.id, 1) -- EEP 16.3 (limited to first entry)
 
     local _, trackId, trackDistance, trackDirection, trackSystem = EEPRollingstockGetTrack(o.id)
     -- EEP 14.2


### PR DESCRIPTION
Die Funktion EEPRollingstockGetTextureText von EEP 16.3 ist nun in EepSimulator.lua und RollingStock.lua vorhanden.
Einschänkung: Es wird nur der Text auf Fläche 1 ausgegeben.

Im Simulator konnte ich das testen, für RollingStock.lua fehlt mit allerdings anscheinend ein geeignetes Fahrzeug aus dem Grundbestand.